### PR TITLE
Fix tar extract in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 
 download: clean
 	curl -skL ${URL} -o opentsdb-${VERSION}_all.deb
-	mkdir ./opentsdb && ar -x opentsdb-${VERSION}_all.deb data.tar.xz && tar zx -xvf data.tar.xz -C ./opentsdb
+	mkdir ./opentsdb && ar -x opentsdb-${VERSION}_all.deb data.tar.xz && tar -xvf data.tar.xz -C ./opentsdb
 	rm data.tar.xz opentsdb-${VERSION}_all.deb
 
 clean:


### PR DESCRIPTION
The goal dowload doesn't work

```
$ make download
rm -rf ./opentsdb
curl -skL https://github.com/OpenTSDB/opentsdb/releases/download/v2.2.0RC3/opentsdb-2.2.0RC3_all.deb -o opentsdb-2.2.0RC3_all.deb
mkdir ./opentsdb && ar -x opentsdb-2.2.0RC3_all.deb data.tar.xz && tar zx -xvf data.tar.xz -C ./opentsdb

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
make: *** [download] Error 2
```
